### PR TITLE
Expand gitignore for Python data science and uv tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,44 @@
-__pycache__
-.ipynb_checkpoints
-.venv
+# Operating system files
+.DS_Store
+
+# Python bytecode and compiled extensions
+__pycache__/
+*.py[cod]
+*.so
+
+# Packaging artefacts
+*.egg-info/
+build/
+dist/
+site/
+
+# Test and lint caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.nox/
+.tox/
+.coverage
+htmlcov/
+
+# Virtual environments
+.venv/
+.venv*/
 .env
+.env*/
+.uv/
+
+# Project configuration helpers
+.python-version
+
+# Notebook noise
+.ipynb_checkpoints/
+*.nbconvert.ipynb
+
+# Data science artefacts
 results*
-.ipynb_checkpoints
+data/*
+
+# Project-specific notebooks
 sportmonks.ipynb
 skill.ipynb
-data/*


### PR DESCRIPTION
## Summary
- expand the root .gitignore to cover common Python bytecode, packaging artefacts, caches, and data outputs
- add ignores for virtual environments and uv-specific directories used in Python data science workflows

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ded79c25808331a9b2a1065c160fd5